### PR TITLE
Remove extra text codecheck yml reference

### DIFF
--- a/codecheck.yml
+++ b/codecheck.yml
@@ -9,9 +9,7 @@ paper:
     - name: Roland J. Baddeley
     - name: Leslie S. Smith
       ORCID: 0000-0002-3716-8013
-  reference: >
-    Network (1992) 3:61-70
-    http://pdfs.semanticscholar.org/7dcf/a42cfe3b59becb441844b72558b361693608.pdf
+  reference: http://pdfs.semanticscholar.org/7dcf/a42cfe3b59becb441844b72558b361693608.pdf
 
 manifest:
   - file: Figure2.png


### PR DESCRIPTION
In the `codecheck.yml` there was extra text in paper reference. I removed this extra text. 
Refer to comments in another PR about this: [link](https://github.com/codecheckers/register/issues/88#issuecomment-2343273428)

@nuest could you review and merge if you're okay with the changes. I do not have permission to merge.