### PR TITLE
Fix codecheck.yaml- Wrap title in quotation marks

### DIFF
--- a/codecheck.yml
+++ b/codecheck.yml
@@ -2,7 +2,7 @@
 version: https://codecheck.org.uk/spec/config/1.0
 
 paper:
-  title: Modeling spatiotemporal domestic wastewater variability: Implications for measuring treatment efficiency
+  title: "Modeling spatiotemporal domestic wastewater variability: Implications for measuring treatment efficiency"
   authors:
     - name: Néstor DelaPaz-Ruíz
       ORCID: 0000-0002-8941-4677


### PR DESCRIPTION
I would get errors reading the `codecheck.yml` file because the paper title contains ":" which is a special character and the title was not wrapped in quotation marks. Fixed this issue by wrapping quotation marks. 

@nuest could you merge this?